### PR TITLE
"Double logout" issue fix

### DIFF
--- a/01-Login/src/app/components/nav-bar/nav-bar.component.html
+++ b/01-Login/src/app/components/nav-bar/nav-bar.component.html
@@ -93,7 +93,7 @@
         <!-- /Responsive login button -->
 
         <!-- Responsive profile dropdown: show if authenticated -->
-        <ul class="navbar-nav d-md-none">
+        <ul class="navbar-nav d-md-none" *ngIf="isAuthenticated">
           <li class="nav-item">
             <span class="user-info" *ngIf="profile">
               <!-- Profile image should be set to the profile picture from the id token -->

--- a/01-Login/src/app/components/nav-bar/nav-bar.component.html
+++ b/01-Login/src/app/components/nav-bar/nav-bar.component.html
@@ -67,14 +67,14 @@
               >
                 <span class="icon icon-profile"></span> Profile
               </a>
-              <a
+              <button
                 href="#"
                 (click)="logout()"
-                class="dropdown-item"
+                class="btn btn-link dropdown-item"
                 id="qsLogoutBtn"
               >
                 <span class="icon icon-power"></span> Log out
-              </a>
+              </button>
             </div>
           </li>
           <!-- /Fullsize dropdown -->
@@ -113,7 +113,9 @@
 
           <li>
             <span class="icon icon-power"></span>
-            <a href="#" id="qsLogoutBtn">Log out</a>
+            <button class="btn btn-link" id="qsLogoutBtn" (click)="logout()">
+              Log out
+            </button>
           </li>
         </ul>
       </div>

--- a/03-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
+++ b/03-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
@@ -96,7 +96,7 @@
         <!-- /Responsive login button -->
 
         <!-- Responsive profile dropdown: show if authenticated -->
-        <ul class="navbar-nav d-md-none">
+        <ul class="navbar-nav d-md-none" *ngIf="isAuthenticated">
           <li class="nav-item">
             <span class="user-info" *ngIf="profile">
               <!-- Profile image should be set to the profile picture from the id token -->

--- a/03-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
+++ b/03-Calling-an-API/src/app/components/nav-bar/nav-bar.component.html
@@ -70,14 +70,14 @@
               >
                 <span class="icon icon-profile"></span> Profile
               </a>
-              <a
+              <button
                 href="#"
                 (click)="logout()"
-                class="dropdown-item"
+                class="btn btn-link dropdown-item"
                 id="qsLogoutBtn"
               >
                 <span class="icon icon-power"></span> Log out
-              </a>
+              </button>
             </div>
           </li>
           <!-- /Fullsize dropdown -->
@@ -116,7 +116,9 @@
 
           <li>
             <span class="icon icon-power"></span>
-            <a href="#" id="qsLogoutBtn">Log out</a>
+            <button class="btn btn-link" id="qsLogoutBtn" (click)="logout()">
+              Log out
+            </button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This fixes an issue reported by a user who was validating the Angular sample with the new SDK, by replacing the logout links with buttons styled as links. The user reported that they would effectively have to logout twice to be _really_ logged out (after logging out once, the page refreshed and they would be logged in again).

The issue only occurs when not on the home page. Because the logout link does not `preventDefault()`, it performs a redirect on its own and the logout Auth0 endpoint never gets called. So when the page refreshes, the login session is rehydrated. Now the user will be on the home page, so when the logout link is clicked again, the logout works.

The links have been changed to buttons (which are more semantically correct for this anyway), which prevents the issue.

This PR also contains a tweak to the UI, which was appearing even when the user is logged out.