### PR TITLE
External-API component refactor

### DIFF
--- a/03-Calling-an-API/src/app/containers/external-api/external-api.component.ts
+++ b/03-Calling-an-API/src/app/containers/external-api/external-api.component.ts
@@ -1,38 +1,21 @@
-import { Component, OnInit } from '@angular/core';
-import { AuthService } from '../../auth/auth.service';
-import Auth0Client from '@auth0/auth0-spa-js/dist/typings/Auth0Client';
-import { HttpClient } from '@angular/common/http';
+import { Component } from '@angular/core';
+import { ApiService } from 'src/app/services/api.service';
 
 @Component({
   selector: 'app-external-api',
   templateUrl: './external-api.component.html',
   styleUrls: ['./external-api.component.css']
 })
-export class ExternalApiComponent implements OnInit {
-  client: Auth0Client;
+export class ExternalApiComponent {
   responseJson: string;
   hasResponse = false;
-  token: string;
 
-  constructor(
-    private authService: AuthService,
-    private httpClient: HttpClient
-  ) {}
-
-  ngOnInit() {
-    this.authService.token.subscribe(token => (this.token = token));
-  }
+  constructor(private apiService: ApiService) {}
 
   async pingApi() {
-    this.httpClient
-      .get('/api/external', {
-        headers: {
-          Authorization: `Bearer ${this.token}`
-        }
-      })
-      .subscribe((response: any) => {
-        this.responseJson = JSON.stringify(response, null, 2).trim();
-        this.hasResponse = true;
-      });
+    const response = await this.apiService.ping();
+
+    this.responseJson = JSON.stringify(response, null, 2).trim();
+    this.hasResponse = true;
   }
 }

--- a/03-Calling-an-API/src/app/services/api.service.ts
+++ b/03-Calling-an-API/src/app/services/api.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { AuthService } from '../auth/auth.service';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ApiService {
+  constructor(
+    private authService: AuthService,
+    private httpClient: HttpClient
+  ) {}
+
+  async ping(): Promise<any> {
+    const client = await this.authService.getAuth0Client();
+    const token = await client.getTokenSilently();
+
+    return this.httpClient
+      .get('/api/external', {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      })
+      .toPromise();
+  }
+}


### PR DESCRIPTION
This is work based on customer feedback.

* Code pertinent to calling the API using `HttpClient` has been refactored into its own API service
* Access token is now retrieved just-in-time before the API call
* Tutorial updated to reflect new code