### PR TITLE
Refactored LoginGuard to support async/await

### DIFF
--- a/01-Login/README.md
+++ b/01-Login/README.md
@@ -485,7 +485,7 @@ import { AuthService } from './auth.service';
 @Injectable({
   providedIn: 'root'
 })
-export class LoginGuard implements CanActivate {
+export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
   async canActivate(

--- a/01-Login/README.md
+++ b/01-Login/README.md
@@ -479,31 +479,32 @@ Open the `src/app/auth/auth.guard.ts` file and replace its contents with the fol
 
 ```js
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { Observable } from 'rxjs';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
-export class AuthGuard implements CanActivate {
-  constructor(private authService: AuthService) {}
+export class LoginGuard implements CanActivate {
+  constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-   | Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+  async canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean | UrlTree> {
+    const client = await this.authService.getAuth0Client();
+    const isAuthenticated = await client.isAuthenticated();
 
-    return this.authService.getAuth0Client().then(client => {
-      return client.isAuthenticated().then(isAuthenticated => {
-        if (isAuthenticated) {
-          return true;
-        }
+    if (isAuthenticated) {
+      return true;
+    }
 
-        client.loginWithRedirect({
-          redirect_uri: `${window.location.origin}/callback`,
-          appState: { target: next.url[0].path }
-        });
-      });
+    client.loginWithRedirect({
+      redirect_uri: `${window.location.origin}/callback`,
+      appState: { target: state.url }
     });
+
+    return false;
   }
 }
 ```

--- a/01-Login/src/app/app-routing.module.ts
+++ b/01-Login/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { HomeComponent } from './containers/home/home.component';
 import { CallbackComponent } from './containers/callback/callback.component';
 import { ProfileComponent } from './containers/profile/profile.component';
-import { LoginGuard } from './auth/login.guard';
+import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
   {
@@ -17,11 +17,11 @@ export const routes: Routes = [
   {
     path: 'profile',
     component: ProfileComponent,
-    canActivate: [LoginGuard]
+    canActivate: [AuthGuard]
   },
   {
     path: 'login',
-    canActivate: [LoginGuard],
+    canActivate: [AuthGuard],
     children: []
   }
 ];

--- a/01-Login/src/app/auth/auth.guard.spec.ts
+++ b/01-Login/src/app/auth/auth.guard.spec.ts
@@ -1,17 +1,17 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { LoginGuard } from './login.guard';
+import { AuthGuard } from './auth.guard';
 
-describe('LoginGuard', () => {
+describe('AuthGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      providers: [LoginGuard]
+      providers: [AuthGuard]
     });
   });
 
-  it('should ...', inject([LoginGuard], (guard: LoginGuard) => {
+  it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
     expect(guard).toBeTruthy();
   }));
 });

--- a/01-Login/src/app/auth/auth.guard.ts
+++ b/01-Login/src/app/auth/auth.guard.ts
@@ -11,7 +11,7 @@ import { AuthService } from './auth.service';
 @Injectable({
   providedIn: 'root'
 })
-export class LoginGuard implements CanActivate {
+export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
   async canActivate(

--- a/01-Login/src/app/auth/login.guard.ts
+++ b/01-Login/src/app/auth/login.guard.ts
@@ -6,7 +6,6 @@ import {
   UrlTree,
   Router
 } from '@angular/router';
-import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
 
 @Injectable({
@@ -15,27 +14,22 @@ import { AuthService } from './auth.service';
 export class LoginGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(
+  async canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ):
-    | Observable<boolean | UrlTree>
-    | Promise<boolean | UrlTree>
-    | boolean
-    | UrlTree {
-    return this.authService.getAuth0Client().then(client => {
-      return client.isAuthenticated().then(isAuthenticated => {
-        if (isAuthenticated) {
-          return true;
-        }
+  ): Promise<boolean | UrlTree> {
+    const client = await this.authService.getAuth0Client();
+    const isAuthenticated = await client.isAuthenticated();
 
-        client.loginWithRedirect({
-          redirect_uri: `${window.location.origin}/callback`,
-          appState: { target: next.url[0].path }
-        });
+    if (isAuthenticated) {
+      return true;
+    }
 
-        return false;
-      });
+    client.loginWithRedirect({
+      redirect_uri: `${window.location.origin}/callback`,
+      appState: { target: state.url }
     });
+
+    return false;
   }
 }

--- a/02-Calling-an-API/src/app/app-routing.module.ts
+++ b/02-Calling-an-API/src/app/app-routing.module.ts
@@ -3,7 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { HomeComponent } from './containers/home/home.component';
 import { CallbackComponent } from './containers/callback/callback.component';
 import { ProfileComponent } from './containers/profile/profile.component';
-import { LoginGuard } from './auth/login.guard';
+import { AuthGuard } from './auth/auth.guard';
 import { ExternalApiComponent } from './containers/external-api/external-api.component';
 
 export const routes: Routes = [
@@ -18,17 +18,17 @@ export const routes: Routes = [
   {
     path: 'profile',
     component: ProfileComponent,
-    canActivate: [LoginGuard]
+    canActivate: [AuthGuard]
   },
   {
     path: 'login',
     children: [],
-    canActivate: [LoginGuard]
+    canActivate: [AuthGuard]
   },
   {
     path: 'external-api',
     component: ExternalApiComponent,
-    canActivate: [LoginGuard]
+    canActivate: [AuthGuard]
   }
 ];
 

--- a/02-Calling-an-API/src/app/auth/auth.guard.spec.ts
+++ b/02-Calling-an-API/src/app/auth/auth.guard.spec.ts
@@ -1,17 +1,17 @@
 import { inject, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { LoginGuard } from './login.guard';
+import { AuthGuard } from './auth.guard';
 
-describe('LoginGuard', () => {
+describe('AuthGuard', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule],
-      providers: [LoginGuard]
+      providers: [AuthGuard]
     });
   });
 
-  it('should ...', inject([LoginGuard], (guard: LoginGuard) => {
+  it('should ...', inject([AuthGuard], (guard: AuthGuard) => {
     expect(guard).toBeTruthy();
   }));
 });

--- a/02-Calling-an-API/src/app/auth/auth.guard.ts
+++ b/02-Calling-an-API/src/app/auth/auth.guard.ts
@@ -11,7 +11,7 @@ import { AuthService } from './auth.service';
 @Injectable({
   providedIn: 'root'
 })
-export class LoginGuard implements CanActivate {
+export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
   async canActivate(

--- a/02-Calling-an-API/src/app/auth/login.guard.ts
+++ b/02-Calling-an-API/src/app/auth/login.guard.ts
@@ -6,7 +6,6 @@ import {
   UrlTree,
   Router
 } from '@angular/router';
-import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
 
 @Injectable({
@@ -15,27 +14,22 @@ import { AuthService } from './auth.service';
 export class LoginGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(
+  async canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ):
-    | Observable<boolean | UrlTree>
-    | Promise<boolean | UrlTree>
-    | boolean
-    | UrlTree {
-    return this.authService.getAuth0Client().then(client => {
-      return client.isAuthenticated().then(isAuthenticated => {
-        if (isAuthenticated) {
-          return true;
-        }
+  ): Promise<boolean | UrlTree> {
+    const client = await this.authService.getAuth0Client();
+    const isAuthenticated = await client.isAuthenticated();
 
-        client.loginWithRedirect({
-          redirect_uri: `${window.location.origin}/callback`,
-          appState: { target: next.url[0].path }
-        });
+    if (isAuthenticated) {
+      return true;
+    }
 
-        return false;
-      });
+    client.loginWithRedirect({
+      redirect_uri: `${window.location.origin}/callback`,
+      appState: { target: state.url }
     });
+
+    return false;
   }
 }


### PR DESCRIPTION
Refactored for both samples. The tutorial in the readme has also been updated to match.

Context: originally Promises were used because I was getting a funky type error when trying to use async/await, as the return type of `canActivate` was incompatible. Turns out it's fine just to refactor the return type of `canActivate` to just return `Promise<T>`, which means async/await can work just fine.

This PR also renames `LoginGuard` to `AuthGuard`, in keeping with the new QS docs.